### PR TITLE
CDATA character validation

### DIFF
--- a/lib/builder/xchar.rb
+++ b/lib/builder/xchar.rb
@@ -64,13 +64,6 @@ module Builder
       159 =>  376,		# latin capital letter y with diaeresis
     }
 
-    # See http://www.w3.org/TR/REC-xml/#dt-chardata for details.
-    PREDEFINED = {
-      38 => '&amp;',		# ampersand
-      60 => '&lt;',		# left angle bracket
-      62 => '&gt;',		# right angle bracket
-    }
-
     # See http://www.w3.org/TR/REC-xml/#charsets for details.
     VALID = [
       0x9, 0xA, 0xD,
@@ -95,7 +88,7 @@ class Fixnum
   def xchr(escape=true)
     n = XChar::CP1252[self] || self
     case n when *XChar::VALID
-      XChar::PREDEFINED[n] or (n<128 ? n.chr : (escape ? "&##{n};" : [n].pack('U*')))
+      n<128 ? n.chr : (escape ? "&##{n};" : [n].pack('U*'))
     else
       '*'
     end

--- a/lib/builder/xmlbase.rb
+++ b/lib/builder/xmlbase.rb
@@ -10,6 +10,7 @@ module Builder
   # XmlBase is a base class for building XML builders.  See
   # Builder::XmlMarkup and Builder::XmlEvents for examples.
   class XmlBase < BlankSlate
+    DELIMITER_ESCAPE = { '&' => '&amp;',  '>' => '&gt;',   '<' => '&lt;' }
 
     # Create an XML markup builder.
     #
@@ -115,11 +116,15 @@ module Builder
     
     require 'builder/xchar'
     def _escape(text)
-      text.to_xs((@encoding != 'utf-8' or $KCODE != 'UTF8'))
+      _escape_delimiters(text).to_xs((@encoding != 'utf-8' or $KCODE != 'UTF8'))
     end
 
     def _escape_quote(text)
       _escape(text).gsub(%r{"}, '&quot;')  # " WART
+    end
+
+    def _escape_delimiters(text)
+      text.gsub(/[&><]/) { |special| DELIMITER_ESCAPE[special] }
     end
 
     def _newline

--- a/lib/builder/xmlmarkup.rb
+++ b/lib/builder/xmlmarkup.rb
@@ -280,7 +280,7 @@ module Builder
     def _special(open, close, data=nil, attrs=nil, order=[])
       _indent
       @target << open
-      @target << data if data
+      @target << data.to_xs if data
       _insert_attributes(attrs, order) if attrs
       @target << close
       _newline

--- a/test/test_markupbuilder.rb
+++ b/test/test_markupbuilder.rb
@@ -351,6 +351,11 @@ class TestSpecialMarkup < Test::Unit::TestCase
     @xml.cdata!("TEST&CHECK")
     assert_equal "<![CDATA[TEST&CHECK]]>\n", @xml.target!
   end
+
+  def test_cdata_with_invalid_characters
+    @xml.cdata!("\x00")
+    assert_equal "<![CDATA[*]]>\n", @xml.target!
+  end
 end
 
 class TestIndentedXmlMarkup < Test::Unit::TestCase

--- a/test/test_xchar.rb
+++ b/test/test_xchar.rb
@@ -20,12 +20,6 @@ class TestXmlEscaping < Test::Unit::TestCase
     assert_equal 'abc', 'abc'.to_xs
   end
 
-  def test_predefined
-    assert_equal '&amp;', '&'.to_xs              # ampersand
-    assert_equal '&lt;',  '<'.to_xs              # left angle bracket
-    assert_equal '&gt;',  '>'.to_xs              # right angle bracket
-  end
-
   def test_invalid
     assert_equal '*', "\x00".to_xs               # null
     assert_equal '*', "\x0C".to_xs               # form feed
@@ -50,7 +44,7 @@ class TestXmlEscaping < Test::Unit::TestCase
   def test_utf8_verbatim
     assert_equal "\xE2\x80\x99", "\xE2\x80\x99".to_xs(false)  # right single quote
     assert_equal "\xC2\xA9",  "\xC2\xA9".to_xs(false)         # copy
-    assert_equal "\xC2\xA9&amp;\xC2\xA9",
+    assert_equal "\xC2\xA9&\xC2\xA9",
       "\xC2\xA9&\xC2\xA9".to_xs(false)                        # copy with ampersand
   end
 end


### PR DESCRIPTION
This pull request does two things:
- It moves markup delimiting out of XChar and into XmlBase where it makes a lot more sense. This is a small cleanup patch that makes the next change easier.
- It adds character validation to CDATA tags, and prevents builder from creating documents with characters that are invalid per http://www.w3.org/TR/REC-xml/#charsets

This commit comes with a caveat: large XML documents that have a lot of data in CDATA tags will generate much more slowly, since builder now applies character validation to CDATA tags.

Sorry for pestering so much. I have had this pull request sitting in limbo for so long and whether it gets pulled or not, I would like to clear it out of my queue.
