### PR TITLE
Please merge this fix to properly run tests on Ruby 1.9.2

### DIFF
--- a/test/test_blankslate.rb
+++ b/test/test_blankslate.rb
@@ -89,6 +89,10 @@ class TestBlankSlate < Test::Unit::TestCase
   end
 
   def setup
+    if Object::const_defined?(:BasicObject) and respond_to?(:skip)
+      skip "BlankSlate is not used in this environment" 
+    end
+
     @bs = BlankSlate.new
   end
 


### PR DESCRIPTION
Hi,

I've been looking at adding Ruby 1.9 support to Gentoo's packaging of builder, but the tests fail here because the blankslate ones aren't properly skipped. This change should take care of those so that they are properly skipped when needed.

HTH,
Diego
