### PR TITLE
Escape newlines inside attributes (with test)

### DIFF
--- a/lib/builder/xmlbase.rb
+++ b/lib/builder/xmlbase.rb
@@ -136,20 +136,21 @@ module Builder
       end
     end
 
-    def _escape_quote(text)
-      _escape(text).gsub(%r{"}, '&quot;')  # " WART
+    def _escape_attribute(text)
+      _escape(text).gsub("\n", "&#10;").gsub("\r", "&#13;").
+        gsub(%r{"}, '&quot;') # " WART
     end
 
     def _newline
       return if @indent == 0
       text! "\n"
     end
-    
+
     def _indent
       return if @indent == 0 || @level == 0
       text!(" " * (@level * @indent))
     end
-    
+
     def _nested_structures(block)
       @level += 1
       block.call(self)

--- a/lib/builder/xmlmarkup.rb
+++ b/lib/builder/xmlmarkup.rb
@@ -317,7 +317,7 @@ module Builder
       when ::Symbol
         value.to_s
       else
-        _escape_quote(value.to_s)
+        _escape_attribute(value.to_s)
       end
     end
 

--- a/test/test_markupbuilder.rb
+++ b/test/test_markupbuilder.rb
@@ -78,7 +78,13 @@ class TestMarkup < Test::Unit::TestCase
     @xml.a("link", :href=>"http://onestepback.org")
     assert_equal %{<a href="http://onestepback.org">link</a>}, @xml.target!
   end
-  
+
+  def test_attributes_with_newlines
+    @xml.abbr("W3C", :title=>"World\nWide\rWeb\r\nConsortium")
+    assert_equal %{<abbr title="World&#10;Wide&#13;Web&#13;&#10;Consortium">W3C</abbr>},
+      @xml.target!
+  end
+
   def test_complex
     @xml.body(:bg=>"#ffffff") { |x|
       x.title("T", :style=>"red")


### PR DESCRIPTION
Hi. I ran into an issue with Builder today where I needed to write out some attributes that contained newlines. Unfortunately, that isn't actually possible at present, as builder simply writes the literal newlines into the attributes rather than escaping them. This does not actually produce invalid XML, but it does produce data loss. Any XML parser that conforms to the spec will discard newlines while parsing, and replace them with a simple space. That means Builder (effectively) converts all newline characters into space characters once the XML has been parsed.

My patch simply changes the `_escape_quote` method into an `_escape_attribute` method, and adds escaping for "\n" and "\r" characters into hex entities "&#10;" and "&#13;" respectively. It passes all of the currently existing tests, and I added one additional test to make sure that the newlines are escaped rather than written out literally.

I did a real-world test of this fix by parsing the output from Builder with Nokogiri, and the attributes are parsed correctly (including newline characters) with my patch.

Thanks!
