### PR TITLE
README and README.rdoc need to be tagged with an encoding as they are not 7-bit ASCII compatible

### DIFF
--- a/README
+++ b/README
@@ -1,3 +1,4 @@
+# coding: UTF-8
 = Project: Builder
 
 == Goal

--- a/README
+++ b/README
@@ -207,7 +207,7 @@ incompatibility are:
   Example:
 
     xml = Builder::Markup.new
-    xml.sample("Iñtërnâtiônàl")
+    xml.sample("IÃ±tÃ«rnÃ¢tiÃ´nÃ l")
     xml.target!  =>
       "<sample>I&#241;t&#235;rn&#226;ti&#244;n&#224;l</sample>"
 
@@ -218,9 +218,9 @@ incompatibility are:
     $KCODE = 'UTF8'
     xml = Builder::Markup.new
     xml.instruct!(:xml, :encoding => "UTF-8")
-    xml.sample("Iñtërnâtiônàl")
+    xml.sample("IÃ±tÃ«rnÃ¢tiÃ´nÃ l")
     xml.target!  =>
-      "<sample>Iñtërnâtiônàl</sample>"
+      "<sample>IÃ±tÃ«rnÃ¢tiÃ´nÃ l</sample>"
 
 == Contact
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -1,3 +1,4 @@
+# coding: UTF-8
 = Project: Builder
 
 == Goal

--- a/README.rdoc
+++ b/README.rdoc
@@ -203,7 +203,7 @@ incompatibility are:
   Example:
 
     xml = Builder::Markup.new
-    xml.sample("I$-1∂∆t(5k(Brn∂®ti∂…n∂¶l")-A
+    xml.sample("I$-1¬∂√Üt(5k(Brn¬∂¬®ti¬∂√ân¬∂¬¶l")-A
     xml.target!  =>
       "<sample>I&#241;t&#235;rn&#226;ti&#244;n&#224;l</sample>"
 
@@ -214,9 +214,9 @@ incompatibility are:
     $KCODE = 'UTF8'
     xml = Builder::Markup.new
     xml.instruct!(:xml, :encoding => "UTF-8")
-    xml.sample("I$-1∂∆t(5k(Brn∂®ti∂…n∂¶l")-A
+    xml.sample("I√±t√´rn√¢ti√¥n√†l")
     xml.target!  =>
-      "<sample>I$-1∂∆t(5k(Brn∂®ti∂…n∂¶l</sample>"-A
+      "<sample>I√±t√´rn√¢ti√¥n√†l</sample>"
 
 == Links
 


### PR DESCRIPTION
I added a coding line to the top of each file and switch the UTF-8 example code at the bottom from ISO-8859-1 to US-ASCII.  This will fix the following error when building RDoc for builder:

```
Installing ri documentation for builder-3.0.0…
unable to convert "\xF1" from ASCII-8BIT to UTF-8 for README, skipping
unable to convert "\xF1" from ASCII-8BIT to UTF-8 for README.rdoc, skipping
```

See also: https://github.com/rdoc/rdoc/issues/43
