### PR TITLE
the _escape method fails when called in ruby 1.8.7

### DIFF
--- a/lib/builder/xmlbase.rb
+++ b/lib/builder/xmlbase.rb
@@ -132,7 +132,11 @@ module Builder
       end
     else
       def _escape(text)
-        text.to_xs((@encoding != 'utf-8' or $KCODE != 'UTF8'))
+        if (text.method(:to_xs).arity == 0)
+          text.to_xs
+        else
+          text.to_xs((@encoding != 'utf-8' or $KCODE != 'UTF8'))
+        end
       end
     end
 


### PR DESCRIPTION
to_xs takes an encoding argument in 1.9.2 but doesn't in 1.8.7.  This causes this method to fail with an ArgumentError when used in 1.8.7.
