### PR TITLE
Added method caching to XmlBuilder instances

### DIFF
--- a/lib/builder/xmlbase.rb
+++ b/lib/builder/xmlbase.rb
@@ -10,7 +10,7 @@ module Builder
   # XmlBase is a base class for building XML builders.  See
   # Builder::XmlMarkup and Builder::XmlEvents for examples.
   class XmlBase < BlankSlate
-
+    
     # Create an XML markup builder.
     #
     # out::      Object receiving the markup.  +out+ must respond to
@@ -31,16 +31,10 @@ module Builder
     # is the tag name, the arguments are the same as the tags
     # implemented via <tt>method_missing</tt>.
     def tag!(sym, *args, &block)
-      method_missing(sym.to_sym, *args, &block)
-    end
-
-    # Create XML markup based on the name of the method.  This method
-    # is never invoked directly, but is called for each markup method
-    # in the markup block.
-    def method_missing(sym, *args, &block)
       text = nil
       attrs = nil
       sym = "#{sym}:#{args.shift}" if args.first.kind_of?(::Symbol)
+      sym = sym.to_sym unless sym.class == Symbol
       args.each do |arg|
         case arg
         when ::Hash
@@ -78,6 +72,13 @@ module Builder
         _newline
       end
       @target
+    end
+
+    # Create XML markup based on the name of the method.  This method
+    # is never invoked directly, but is called for each markup method
+    # in the markup block.
+    def method_missing(sym, *args, &block)
+      tag!(sym, *args, &block)
     end
 
     # Append text to the output target.  Escape any markup.  May be
@@ -157,4 +158,5 @@ module Builder
       @level -= 1
     end
   end
+  
 end

--- a/lib/builder/xmlbase.rb
+++ b/lib/builder/xmlbase.rb
@@ -11,10 +11,6 @@ module Builder
   # Builder::XmlMarkup and Builder::XmlEvents for examples.
   class XmlBase < BlankSlate
     
-    class << self
-      attr_accessor :cache_method_calls
-    end
-    
     # Create an XML markup builder.
     #
     # out::      Object receiving the markup.  +out+ must respond to
@@ -38,7 +34,7 @@ module Builder
       text = nil
       attrs = nil
       sym = "#{sym}:#{args.shift}" if args.first.kind_of?(::Symbol)
-      sym = sym.to_sym unless sym.class == Symbol
+      sym = sym.to_sym unless sym.class == ::Symbol
       args.each do |arg|
         case arg
         when ::Hash
@@ -82,7 +78,7 @@ module Builder
     # is never invoked directly, but is called for each markup method
     # in the markup block that isn't cached.
     def method_missing(sym, *args, &block)
-      cache_method_call(sym) if XmlBase.cache_method_calls
+      cache_method_call(sym)
       tag!(sym, *args, &block)
     end
 
@@ -163,7 +159,7 @@ module Builder
       @level -= 1
     end
 
-    # If XmlBase.cache_method_calls = true, we dynamicly create the method
+    # If method missing is hit, we dynamicly create the method
     # missed as an instance method on the XMLBase object. Because XML
     # documents are usually very repetative in nature, the next node will
     # be handled by the new method instead of method_missing. As
@@ -177,7 +173,5 @@ module Builder
       NEW_METHOD
     end
   end
-  
-  XmlBase.cache_method_calls = true
   
 end

--- a/test/test_method_caching.rb
+++ b/test/test_method_caching.rb
@@ -1,0 +1,34 @@
+#!/usr/bin/env ruby
+
+#--
+# Portions copyright 2011 by Bart ten Brinke (info@retrosync.com).
+# All rights reserved.
+
+# Permission is granted for use, copying, modification, distribution,
+# and distribution of modified versions of this work as long as the
+# above copyright notice is included.
+#++
+
+require 'test/unit'
+require 'test/preload'
+require 'builder'
+
+class TestMethodCaching < Test::Unit::TestCase
+
+  def test_method_call_caching
+    xml = Builder::XmlMarkup.new
+    xml.cache_me
+    assert xml.respond_to?(:cache_me)
+  end
+
+  def test_method_call_caching_disabled
+    Builder::XmlBase.cache_method_calls = false
+    xml = Builder::XmlMarkup.new
+    xml.do_not_cache_me
+    assert ! defined? xml.do_not_cache_me
+
+    Builder::XmlBase.cache_method_calls = true    
+  end
+
+end
+

--- a/test/test_method_caching.rb
+++ b/test/test_method_caching.rb
@@ -21,14 +21,5 @@ class TestMethodCaching < Test::Unit::TestCase
     assert xml.respond_to?(:cache_me)
   end
 
-  def test_method_call_caching_disabled
-    Builder::XmlBase.cache_method_calls = false
-    xml = Builder::XmlMarkup.new
-    xml.do_not_cache_me
-    assert ! defined? xml.do_not_cache_me
-
-    Builder::XmlBase.cache_method_calls = true    
-  end
-
 end
 


### PR DESCRIPTION
Hello,
first of all: I really love the xml builder. The interface is clean and the implementation is simple and clean.
There were however two things that I felt that needed some improvement:
- First commit: Moved all logic from method_missing to tag! function. As stated in the original comments on the method_missing: "method_missing should never be called directly" and it also should not have complex logic in it. This commit addresses this.
- Second commit:  This commit dynamically creates any method missed as an instance method on the XMLBuilder instance object. Because XML documents are usually very repetitive in nature, the next node will be handled by the new method instead of method_missing. As method_missing is very slow, this speeds up document generation significantly.

Greetings, Bart ten Brinke
