### PR TITLE
Exclude TAGS file from builder gem

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -52,6 +52,7 @@ rd = Rake::RDocTask.new("rdoc") { |rdoc|
   rdoc.title    = "Builder for Markup"
   rdoc.options << '--line-numbers' << '--inline-source' << '--main' << 'README.rdoc'
   rdoc.rdoc_files.include('lib/**/*.rb', '[A-Z]*', 'doc/**/*.rdoc')
+  rdoc.rdoc_files.exclude('TAGS')
   rdoc.template = 'doc/jamis.rb'
 }
 


### PR DESCRIPTION
This should fix the 2.8mb TAGS file that shows up in the distributed gems. It was getting picked up in the rdoc_files list in the gemspec, which included a '[A-Z]*' glob.
