### PR TITLE
CDATA closing sequences in the string need to be "escaped" for cdata! method

### DIFF
--- a/lib/builder/xmlmarkup.rb
+++ b/lib/builder/xmlmarkup.rb
@@ -263,7 +263,7 @@ module Builder
     #
     def cdata!(text)
       _ensure_no_block ::Kernel::block_given?
-      _special("<![CDATA[", "]]>", text, nil)
+      _special("<![CDATA[", "]]>", text.gsub(']]>', ']]]]><![CDATA[>'), nil)
     end
     
     private


### PR DESCRIPTION
If the String to be included in a CDATA section (the 'cdata!' method) includes the CDATA closing sequence (']]>'), the produced XML will be invalid because the intended closing sequence is no longer legal. Closing sequences in the String need to be "escaped". See http://en.wikipedia.org/wiki/Cdata#Nesting
