### PR TITLE
Correctly exclude css test.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -64,7 +64,7 @@ PKG_FILES = FileList[
   'test/**/*.rb',
   'scripts/**/*.rb'
 ]
-PKG_FILES.exclude('test/testcssbuilder.rb')
+PKG_FILES.exclude('test/test_cssbuilder.rb')
 PKG_FILES.exclude('lib/builder/css.rb')
 
 BLANKSLATE_FILES = FileList[


### PR DESCRIPTION
It seems that test_cssbuilder.rb should be excluded, since lib/builder/css.rb is excluded and testcssbuilder.rb does not exists.
