### PR TITLE
Check if method was already cached before method definition.

### DIFF
--- a/lib/builder/xmlbase.rb
+++ b/lib/builder/xmlbase.rb
@@ -180,8 +180,10 @@ module Builder
     # significantly.
     def cache_method_call(sym)
       class << self; self; end.class_eval do
-        define_method(sym) do |*args, &block|
-          tag!(sym, *args, &block)
+        unless method_defined?(sym)
+          define_method(sym) do |*args, &block|
+            tag!(sym, *args, &block)
+          end
         end
       end
     end


### PR DESCRIPTION
In case of direct `method_missing` call (like here in Rails: https://github.com/rails/rails/blob/c449462f45d342258a01313c0ff46279d268719d/activesupport/lib/active_support/core_ext/array/conversions.rb#L216) cached method will be redefined each time. Commit fixes this behavior.
