### PR TITLE
Change to String, raise_error last argument accept String

### DIFF
--- a/test/test_method_caching.rb
+++ b/test/test_method_caching.rb
@@ -54,7 +54,7 @@ class TestMethodCaching < Test::Unit::TestCase
     def xml.method_missing(*args)
       ::Kernel.fail StandardError, "SHOULD BE CALLED"
     end
-    assert_raise(StandardError, /SHOULD BE CALLED/) do
+    assert_raise(StandardError, "SHOULD BE CALLED") do
       xml.do_not_cache_me
     end
   end


### PR DESCRIPTION
http://apidock.com/ruby/Test/Unit/Assertions/assert_raise
If the last argument is a String, it will be used as the error message.

My environment: Ruby 2.0.0-preview2
