### PR TITLE
Add explicit_nil_handling option to codebase

### DIFF
--- a/lib/builder/xmlbase.rb
+++ b/lib/builder/xmlbase.rb
@@ -52,7 +52,6 @@ module Builder
           attrs ||= {}
           attrs.merge!(arg)
         when nil
-          # do nothing
           attrs ||= {}
           attrs.merge!({nil: true}) if explicit_nil_handling?
         else

--- a/lib/builder/xmlbase.rb
+++ b/lib/builder/xmlbase.rb
@@ -30,6 +30,13 @@ module Builder
       @level  = initial
       @encoding = encoding.downcase
     end
+    def explicit_nil_handling?
+       if  @explicit_nil_handling == true
+         true
+       else
+         false
+       end
+    end
 
     # Create a tag named +sym+.  Other than the first argument which
     # is the tag name, the arguments are the same as the tags
@@ -46,6 +53,8 @@ module Builder
           attrs.merge!(arg)
         when nil
           # do nothing
+          attrs ||= {}
+          attrs.merge!({nil: true}) if explicit_nil_handling?
         else
           text ||= ''
           text << arg.to_s

--- a/lib/builder/xmlmarkup.rb
+++ b/lib/builder/xmlmarkup.rb
@@ -186,6 +186,7 @@ module Builder
     def initialize(options={})
       indent = options[:indent] || 0
       margin = options[:margin] || 0
+      @explicit_nil_handling = options[:explicit_nil_handling] || false
       super(indent, margin)
       @target = options[:target] || ""
     end

--- a/test/test_markupbuilder.rb
+++ b/test/test_markupbuilder.rb
@@ -155,6 +155,22 @@ class TestMarkup < Test::Unit::TestCase
     @xml.div { |x| x.text! "<hi>"; x.em("H&R Block") }
     assert_equal %{<div>&lt;hi&gt;<em>H&amp;R Block</em></div>}, @xml.target!
   end
+  def test_explicit_nil_handling
+    b = Builder::XmlMarkup.new explicit_nil_handling: true
+    b.tag! "foo", nil
+    assert_equal %{<foo nil="true"/>}, b.target!
+
+    b = Builder::XmlMarkup.new explicit_nil_handling: true
+    b.div("ns:xml"=>:"&xml;") { |x| x << "<h&i>"; x.em("H&R Block") }
+    assert_equal %{<div ns:xml="&xml;"><h&i><em>H&amp;R Block</em></div>}, b.target!
+
+    b = Builder::XmlMarkup.new explicit_nil_handling: true
+    n = 3
+    b.ol { |x| n.times { x.li(n) } }
+    assert_equal "<ol><li>3</li><li>3</li><li>3</li></ol>", b.target!
+
+
+  end
 
   def test_non_escaping
     @xml.div("ns:xml"=>:"&xml;") { |x| x << "<h&i>"; x.em("H&R Block") }


### PR DESCRIPTION
Fixes issue 33 which requests that there be an option to specify how Builder treats nil values from initialization. Without specifying the explicit_nil_handling option as true, the codebase functions the same way. 

``` ruby
    b = Builder::XmlMarkup.new 
    b.tag! "foo", "bar"
```

 yields an output of 

``` xml
<foo>bar</foo>
```

as does

``` ruby
    b = Builder::XmlMarkup.new explicit_nil_handling: false
    b.tag! "foo", "bar"
```

However, when a tag has a nil value, and the option is turned on, it adds a nil="true" attribute to the tag, in order to match the way Rails explicitly denotes nil values when rendering ActiveRecord objects as xml.

``` ruby
    b = Builder::XmlMarkup.new explicit_nil_handling: true
    b.tag! "foo", nil
```

yields

``` xml
<foo nil="true"/>
```

commit 430b9762c436f180db8686407b5002cb4f71e8b9
Author: Dermot Haughey hderms@gmail.com
Date:   Tue Jan 15 19:36:00 2013 -0600

```
Add test
```

commit b9adb4d916ae1cf897ea2c1f39f5ad0c0def4460
Author: Dermot Haughey hderms@gmail.com
Date:   Tue Jan 15 19:35:50 2013 -0600

```
Cleanup of code
```

commit 8e8a7873b48e956e4642d31265dc767b5fafb096
Author: Dermot Haughey hderms@gmail.com
Date:   Tue Jan 15 19:25:42 2013 -0600

```
Make changes to add option
```
