### PR TITLE
Add encoding: iso-8859-1 comment

### DIFF
--- a/test/performance.rb
+++ b/test/performance.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# encoding: iso-8859-1
 
 #--
 # Portions copyright 2004 by Jim Weirich (jim@weirichhouse.org).
@@ -13,7 +14,7 @@
 require 'builder/xmlmarkup'
 require 'benchmark'
 
-text = "This is a test of the new xml markup. Iñtërnâtiônàlizætiøn\n" * 10000
+text = "This is a test of the new xml markup. Iï¿½tï¿½rnï¿½tiï¿½nï¿½lizï¿½tiï¿½n\n" * 10000
 
 include Benchmark          # we need the CAPTION and FMTSTR constants
 include Builder


### PR DESCRIPTION
While this is some black magic, apparently 1.9 tries to parse this as
US-ASCII on my system. This addition of this line will allow ruby to 
know that there are non-ascii characters involved.

FATAL: ..../vendor/gems/builder-3.0.4/test/performance.rb:16: invalid multibyte char (US-ASCII)
