### PR TITLE
Add parameter so text can be optionally not escaped for `tag!`

### DIFF
--- a/lib/builder/xmlbase.rb
+++ b/lib/builder/xmlbase.rb
@@ -41,6 +41,7 @@ module Builder
     def tag!(sym, *args, &block)
       text = nil
       attrs = nil
+      escape_text = true
       sym = "#{sym}:#{args.shift}" if args.first.kind_of?(::Symbol)
       sym = sym.to_sym unless sym.class == ::Symbol
       args.each do |arg|
@@ -51,6 +52,8 @@ module Builder
         when nil
           attrs ||= {}
           attrs.merge!({:nil => true}) if explicit_nil_handling?
+        when true, false
+          escape_text = arg
         else
           text ||= ''
           text << arg.to_s
@@ -78,7 +81,11 @@ module Builder
       else
         _indent
         _start_tag(sym, attrs)
-        text! text
+        if escape_text
+          text! text
+        else
+          self << text
+        end
         _end_tag(sym)
         _newline
       end

--- a/test/test_markupbuilder.rb
+++ b/test/test_markupbuilder.rb
@@ -194,6 +194,11 @@ class TestMarkup < Test::Unit::TestCase
     assert_equal %{<div ns:xml="&xml;"><h&i><em>H&amp;R Block</em></div>}, @xml.target!
   end
 
+  def test_dont_escape
+    @xml.div({"id"=>2}, false, 'H&amp;R Block')
+    assert_equal %{<div id="2">H&amp;R Block</div>}, @xml.target!
+  end
+
   def test_return_value
     str = @xml.x("men")
     assert_equal @xml.target!, str


### PR DESCRIPTION
If I want to add node such as `apples &amp; oranges` without double escaping it, I've to do it with block. such as

``` ruby
xml = Builder::XmlMarkup.new({:indent => 2})
xml.root {
    xml.node { xml << 'apples &amp; oranges' }
}
```

but output isn't nice...

```
<root>
  <node>
apples &amp; oranges  </node>
</root>
```

`_indent` is private and so it wouldn't be easy to add indentation myself.

With this PR, I added option to `tag!` that you can specify whether to escape text or not. So we can simply

``` ruby
xml.node(false, 'apples &amp; oranges')
```

we get nice result

```
<root>
  <node>apples &amp; oranges</node>
</root>
```

with current implementation, or with `xml.node(true, 'apples &amp; oranges')` or `xml.node('apples &amp; oranges')` it would be double escaped

```
<root>
  <node>apples &amp;amp; oranges</node>
</root>
```
