### PR TITLE
Don't shell out to RVM

### DIFF
--- a/rakelib/tags.rake
+++ b/rakelib/tags.rake
@@ -12,7 +12,7 @@ module Tags
 
   PROJECT_DIR = ['.']
 
-  RVM_GEMDIR = File.join(`rvm gemdir`.strip, "gems")
+  RVM_GEMDIR = File.join(Gem.dir, "gems")
   SYSTEM_DIRS = File.exists?(RVM_GEMDIR) ? RVM_GEMDIR : []
 
   module_function


### PR DESCRIPTION
Without this patch, I can't even run `rake -T`:

```
~/tmp/builder master 2.1.0-github1 λ rake -T
rake aborted!
No such file or directory - rvm
/Users/charlie/tmp/builder/rakelib/tags.rake:15:in ``'
/Users/charlie/tmp/builder/rakelib/tags.rake:15:in `<module:Tags>'
/Users/charlie/tmp/builder/rakelib/tags.rake:3:in `<top (required)>'
(See full trace by running task with --trace)
```
