### PR TITLE
Avoid Ruby 2.4.0 warnings

### DIFF
--- a/builder.gemspec
+++ b/builder.gemspec
@@ -1,18 +1,14 @@
 require './lib/builder/version'
-require 'rake/file_list'
 
 PKG_VERSION = Builder::VERSION
 
-PKG_FILES = Rake::FileList[
+PKG_FILES = Dir[
   '[A-Z]*',
   'doc/**/*',
   'lib/**/*.rb',
   'test/**/*.rb',
   'rakelib/**/*'
 ]
-PKG_FILES.exclude('test/test_cssbuilder.rb')
-PKG_FILES.exclude('lib/builder/css.rb')
-PKG_FILES.exclude('TAGS')
 
 Gem::Specification.new do |s|
 
@@ -29,7 +25,7 @@ simple to do.  Currently the following builder objects are supported:
 * XML Events
 }
 
-  s.files = PKG_FILES.to_a
+  s.files = PKG_FILES
   s.require_path = 'lib'
 
   s.test_files = PKG_FILES.select { |fn| fn =~ /^test\/test/ }

--- a/builder.gemspec
+++ b/builder.gemspec
@@ -1,0 +1,48 @@
+require './lib/builder/version'
+require 'rake/file_list'
+
+PKG_VERSION = Builder::VERSION
+
+PKG_FILES = Rake::FileList[
+  '[A-Z]*',
+  'doc/**/*',
+  'lib/**/*.rb',
+  'test/**/*.rb',
+  'rakelib/**/*'
+]
+PKG_FILES.exclude('test/test_cssbuilder.rb')
+PKG_FILES.exclude('lib/builder/css.rb')
+PKG_FILES.exclude('TAGS')
+
+Gem::Specification.new do |s|
+
+  #### Basic information.
+
+  s.name = 'builder'
+  s.version = PKG_VERSION
+  s.summary = "Builders for MarkUp."
+  s.description = %{\
+Builder provides a number of builder objects that make creating structured data
+simple to do.  Currently the following builder objects are supported:
+
+* XML Markup
+* XML Events
+}
+
+  s.files = PKG_FILES.to_a
+  s.require_path = 'lib'
+
+  s.test_files = PKG_FILES.select { |fn| fn =~ /^test\/test/ }
+
+  s.has_rdoc = true
+  # s.extra_rdoc_files = rd.rdoc_files.reject { |fn| fn =~ /\.rb$/ }.to_a
+  s.rdoc_options <<
+    '--title' <<  'Builder -- Easy XML Building' <<
+    '--main' << 'README.rdoc' <<
+    '--line-numbers'
+
+  s.author = "Jim Weirich"
+  s.email = "jim.weirich@gmail.com"
+  s.homepage = "http://onestepback.org"
+  s.license = 'MIT'
+end

--- a/lib/builder/xchar.rb
+++ b/lib/builder/xchar.rb
@@ -19,7 +19,7 @@ end
 
 if ! defined?(Builder::XChar) and ! String.method_defined?(:encode)
   Builder.check_for_name_collision(String, "to_xs")
-  Builder.check_for_name_collision(Fixnum, "xchr")
+  Builder.check_for_name_collision(Integer, "xchr")
 end
 
 ######################################################################
@@ -108,7 +108,7 @@ if String.method_defined?(:encode)
       INVALID_XML_CHAR = Regexp.new('[^'+
         Builder::XChar::VALID.map { |item|
           case item
-          when Fixnum
+          when Integer
             [item].pack('U').force_encoding('utf-8')
           when Range
             [item.first, '-'.ord, item.last].pack('UUU').force_encoding('utf-8')
@@ -160,9 +160,9 @@ if String.method_defined?(:encode)
 else
 
   ######################################################################
-  # Enhance the Fixnum class with a XML escaped character conversion.
+  # Enhance the Integer class with a XML escaped character conversion.
   #
-  class Fixnum
+  class Integer
     XChar = Builder::XChar if ! defined?(XChar)
   
     # XML escaped version of chr. When <tt>escape</tt> is set to false


### PR DESCRIPTION
I know Jim is no longer here to merge this fix,
but I've forked the gem, to remove deprecation warnings which occur with ruby 2.4.0

I've also added a gemspec, so you can use our fork;

``` ruby
gem 'builder', github: 'gogovan/builder'
```