### PR TITLE
Fix spelling mistake in example

### DIFF
--- a/lib/builder/xmlmarkup.rb
+++ b/lib/builder/xmlmarkup.rb
@@ -154,7 +154,7 @@ module Builder
   #
   #     xml_builder = Builder::XmlMarkup.new
   #     xml_builder.div { |xml|
-  #       xml.stong("text")
+  #       xml.strong("text")
   #     }
   #
   class XmlMarkup < XmlBase


### PR DESCRIPTION
'stong' to 'strong'